### PR TITLE
Enable static linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,9 @@ endif
 ifeq (,$(findstring nostrip,$(chihuahua_BUILD_OPTIONS)))
   ldflags += -w -s
 endif
+ifeq ($(LINK_STATICALLY),true)
+        ldflags += -linkmode=external -extldflags "-Wl,-z,muldefs -static"
+endif
 ldflags += $(LDFLAGS)
 ldflags := $(strip $(ldflags))
 


### PR DESCRIPTION
Otherwise Docker builds would build images with the a bunch of symbol links missing:
```
Error loading shared library libgcc_s.so.1: No such file or directory (needed by /usr/bin/chihuahuad)
Error relocating /usr/bin/chihuahuad: _Unwind_Resume: symbol not found
Error relocating /usr/bin/chihuahuad: _Unwind_Backtrace: symbol not found
Error relocating /usr/bin/chihuahuad: _Unwind_GetIPInfo: symbol not found
Error relocating /usr/bin/chihuahuad: _Unwind_RaiseException: symbol not found
Error relocating /usr/bin/chihuahuad: _Unwind_SetGR: symbol not found
Error relocating /usr/bin/chihuahuad: _Unwind_GetDataRelBase: symbol not found
Error relocating /usr/bin/chihuahuad: _Unwind_FindEnclosingFunction: symbol not found
Error relocating /usr/bin/chihuahuad: _Unwind_GetIP: symbol not found
Error relocating /usr/bin/chihuahuad: _Unwind_GetLanguageSpecificData: symbol not found
Error relocating /usr/bin/chihuahuad: _Unwind_GetTextRelBase: symbol not found
Error relocating /usr/bin/chihuahuad: _Unwind_DeleteException: symbol not found
Error relocating /usr/bin/chihuahuad: _Unwind_GetRegionStart: symbol not found
Error relocating /usr/bin/chihuahuad: __register_frame: symbol not found
Error relocating /usr/bin/chihuahuad: __deregister_frame: symbol not found
Error relocating /usr/bin/chihuahuad: _Unwind_SetIP: symbol not found
Error relocating /usr/bin/chihuahuad: _Unwind_GetCFA: symbol not found
``` 