### PR TITLE
Fixed typo in app.go

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -104,7 +104,7 @@ const (
 	Name                 = "chihuahua"
 	v1UpgradeName        = "angryandy"
 	v2UpgradeName        = "chiwawasm"
-	v202UpgradeName      = "minpropdesposit"
+	v202UpgradeName      = "minpropdeposit"
 )
 
 // this line is used by starport scaffolding # stargate/wasm/app/enabledProposals


### PR DESCRIPTION
Fixed typo in app.go so that `v202UpgradeName  = "minpropdeposit"` instead of `v202UpgradeName  = "minpropdesposit"`