### PR TITLE
dependabot

### DIFF
--- a/.github/.dependabot.yml
+++ b/.github/.dependabot.yml
@@ -1,0 +1,28 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+
+
+  - package-ecosystem: gomod
+    directory: "/"
+      # Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+
+
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: daily


### PR DESCRIPTION
Dependabot keeps dependencies up to date.

Changes nothing and should be merged. 
