### PR TITLE
go 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ChihuahuaChain/chihuahua
 
-go 1.18
+go 1.19
 
 require (
 	github.com/CosmWasm/wasmd v0.29.1


### PR DESCRIPTION
- require using go1.19


This PR makes it so that all validators building their own binaries are required to use go 1.19.

Go 1.18 and 1.19 sometimes result in different cryptographic hashes for snapshots, so I will also make a state sync script that verifies that this code works correctly with 1.19
