### PR TITLE
annotate replaces in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -131,9 +131,12 @@ require (
 )
 
 replace (
+	// ics23 patch for dragonberry
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
+	// forked cosmos-sdk with minimum commission code
 	github.com/cosmos/cosmos-sdk => github.com/ChihuahuaChain/cosmos-sdk v0.45.9-chihuahua
+	// Use cosmos-flavored protocol buffers
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
-	//github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
+	// use a grpc version compatible with cosmos-flavored protocol buffers
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 )


### PR DESCRIPTION
This PR annotates the packages that we replace in go.mod to make puppy's vet visits easier if she ever gets sick again. 