### PR TITLE
retract

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -140,3 +140,5 @@ replace (
 	// use a grpc version compatible with cosmos-flavored protocol buffers
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 )
+
+retract v2.2.2

--- a/go.mod
+++ b/go.mod
@@ -141,4 +141,5 @@ replace (
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 )
 
+// we're retracting v2.2.2 because it broke semantic versioning
 retract v2.2.2


### PR DESCRIPTION
- retract v2.2.2 because it should have been v2.3.0 because of breaking changes
