### PR TITLE
Github actions: Fix warning Node.js 12 actions are deprecated.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
           
           
 # now uploads genesis.json and bin
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: chihuahuad ${{ matrix.targetos }} ${{ matrix.arch }}
           path: cmd/chihuahuad


### PR DESCRIPTION
There's a warning in the github actions outpout: Node.js 12 actions are deprecated.
Please update the following actions to use Node.js 16: actions/upload-artifact@v2.

This will update the actions/upload-artifact to v3 to use a supported nodeJS version