### PR TITLE
Updated error message to match required Go version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,12 @@ build-reproducible-generic: check-go-version go.sum
 
 # Add check to make sure we are using the proper Go version before proceeding with anything
 check-go-version:
+<<<<<<< Updated upstream
 	@if ! go version | grep -q "go1.19"; then \
 		echo "\033[0;31mERROR:\033[0m Go version 1.19 is required for compiling chihuahuad. It looks like you are using" "$(shell go version) \nThere are potential consensus-breaking changes that can occur when running binaries compiled with different versions of Go. Please download Go version 1.19 and retry. Thank you!"; \
+=======
+	@if ! go version | grep -q "go1.20"; then \
+		echo "\033[0;31mERROR:\033[0m Go version 1.20 is required for compiling chihuahuad. It looks like you are using" "$(shell go version) \nThere are potential consensus-breaking changes that can occur when running binaries compiled with different versions of Go. Please download Go version 1.20 and retry. Thank you!"; \
+>>>>>>> Stashed changes
 		exit 1; \
 	fi


### PR DESCRIPTION
Apologies if the formatting isn't proper, I haven't tried to commit a file that was from a specific release in a detached head state. Noticed the error not matching the required Go version when trying to compile for the next upgrade, and just wanted to fix the error message.