### PR TITLE
update docker & makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG IMG_TAG=latest
 ARG PLATFORM="linux/amd64"
-ARG GO_VERSION="1.19"
+ARG GO_VERSION="1.20"
 ARG RUNNER_IMAGE="gcr.io/distroless/static"
 
 FROM --platform=${PLATFORM} golang:${GO_VERSION}-alpine as builder
@@ -13,10 +13,10 @@ COPY . .
 # For more details see https://github.com/CosmWasm/wasmvm#builds-of-libwasmvm
 ARG ARCH=x86_64
 # See https://github.com/CosmWasm/wasmvm/releases
-ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.2.1/libwasmvm_muslc.aarch64.a /lib/libwasmvm_muslc.aarch64.a
-ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.2.1/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.x86_64.a
-RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep 86bc5fdc0f01201481c36e17cd3dfed6e9650d22e1c5c8983a5b78c231789ee0
-RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep a00700aa19f5bfe0f46290ddf69bf51eb03a6dfcd88b905e1081af2e42dbbafc
+ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.3.0/libwasmvm_muslc.aarch64.a /lib/libwasmvm_muslc.aarch64.a
+ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.3.0/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.x86_64.a
+RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep b1610f9c8ad8bdebf5b8f819f71d238466f83521c74a2deb799078932e862722
+RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep b4aad4480f9b4c46635b4943beedbb72c929eab1d1b9467fe3b43e6dbf617e32
 RUN cp /lib/libwasmvm_muslc.${ARCH}.a /lib/libwasmvm_muslc.a
 
 ENV PACKAGES curl make git libc-dev bash gcc linux-headers eudev-dev python3

--- a/Makefile
+++ b/Makefile
@@ -98,15 +98,15 @@ build: check-go-version
 
 BUILD_TARGETS := build install
 
-build-reproducible-all: check-go-version build-reproducible-amd64 build-reproducible-arm64
+build-reproducible-all: build-reproducible-amd64 build-reproducible-arm64
 
-build-reproducible-amd64: check-go-version
+build-reproducible-amd64:
 	ARCH=x86_64 PLATFORM=linux/amd64 $(MAKE) build-reproducible-generic
 
-build-reproducible-arm64: check-go-version
+build-reproducible-arm64:
 	ARCH=aarch64 PLATFORM=linux/arm64 $(MAKE) build-reproducible-generic
 	
-build-reproducible-generic: check-go-version go.sum
+build-reproducible-generic: go.sum
 	$(DOCKER) rm $(subst /,-,latest-build-$(PLATFORM)) || true
 	DOCKER_BUILDKIT=1 $(DOCKER) build -t latest-build-$(PLATFORM) \
 		--build-arg ARCH=$(ARCH) \


### PR DESCRIPTION
Fixes the static build of the binary

No need to check the go version as it's specified in Docker, and update wasmvm libs to 1.3.0