### PR TITLE
bump version  in go.mod to go 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ChihuahuaChain/chihuahua
 
-go 1.19
+go 1.20
 
 require (
 	github.com/CosmWasm/wasmd v0.41.0


### PR DESCRIPTION
I mainly need this for automation tools, but seeing how it's a requirement in the makefile/builds anyway, it shouldn't do any harm