### PR TITLE
Perm liquidity

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -173,7 +173,7 @@ import (
 const (
 	Bech32Prefix = "chihuahua"
 	Name         = "chihuahua"
-	UpgradeName  = "v9.0.2"
+	UpgradeName  = "v9.0.3"
 	NodeDir      = ".chihuahuad"
 )
 
@@ -1398,6 +1398,10 @@ func (app *App) RegisterUpgradeHandlers(cfg module.Configurator) {
 
 	})
 
+	app.UpgradeKeeper.SetUpgradeHandler("v9.0.3", func(ctx context.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		return app.mm.RunMigrations(ctx, cfg, vm)
+
+	})
 }
 
 // SimulationManager implements the SimulationApp interface

--- a/app/app.go
+++ b/app/app.go
@@ -576,6 +576,7 @@ func New(
 	app.LiquidityKeeper = liquiditykeeper.NewKeeper(
 		appCodec, keys[liquiditytypes.StoreKey],
 		app.BankKeeper, app.AccountKeeper, app.DistrKeeper,
+		authtypes.NewModuleAddress(govtypes.ModuleName),
 	)
 
 	// ... other modules keepers

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	cosmossdk.io/x/nft v0.1.1
 	cosmossdk.io/x/tx v0.13.7
 	cosmossdk.io/x/upgrade v0.1.4
-	github.com/Victor118/liquidity v1.7.7
+	github.com/Victor118/liquidity v1.8.0
 	github.com/cometbft/cometbft v0.38.15
 	github.com/cosmos/cosmos-db v1.1.1
 	github.com/cosmos/ibc-apps/modules/ibc-hooks/v8 v8.0.0
@@ -237,5 +237,4 @@ replace (
 
 	// pin version! 126854af5e6d has issues with the store so that queries fail
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
-
 )

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	cosmossdk.io/x/nft v0.1.1
 	cosmossdk.io/x/tx v0.13.7
 	cosmossdk.io/x/upgrade v0.1.4
-	github.com/Victor118/liquidity v1.8.0
+	github.com/Victor118/liquidity v1.8.1
 	github.com/cometbft/cometbft v0.38.15
 	github.com/cosmos/cosmos-db v1.1.1
 	github.com/cosmos/ibc-apps/modules/ibc-hooks/v8 v8.0.0

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	cosmossdk.io/x/nft v0.1.1
 	cosmossdk.io/x/tx v0.13.7
 	cosmossdk.io/x/upgrade v0.1.4
-	github.com/Victor118/liquidity v1.8.1
+	github.com/Victor118/liquidity v1.8.2
 	github.com/cometbft/cometbft v0.38.15
 	github.com/cosmos/cosmos-db v1.1.1
 	github.com/cosmos/ibc-apps/modules/ibc-hooks/v8 v8.0.0

--- a/go.sum
+++ b/go.sum
@@ -243,8 +243,8 @@ github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
-github.com/Victor118/liquidity v1.8.0 h1:GBWPbZs2019ja2W69ZjO5Hiy1zsG8kAYn0Dbr+qLA1k=
-github.com/Victor118/liquidity v1.8.0/go.mod h1:RRGlMTp7z3AKiwbsc9pu4g0hn/UpEyuCrtp3fmzHlGI=
+github.com/Victor118/liquidity v1.8.1 h1:Sbv7yR+F1rSFPtxlGKazCio/bsAL11044qic/aYHUDQ=
+github.com/Victor118/liquidity v1.8.1/go.mod h1:RRGlMTp7z3AKiwbsc9pu4g0hn/UpEyuCrtp3fmzHlGI=
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/adlio/schema v1.3.6 h1:k1/zc2jNfeiZBA5aFTRy37jlBIuCkXCm0XmvpzCKI9I=

--- a/go.sum
+++ b/go.sum
@@ -243,8 +243,8 @@ github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
-github.com/Victor118/liquidity v1.7.7 h1:sHW4qR2FxJiM9P7ReKCOL3IZHDM+bx+OVWuWAbZ5+Fg=
-github.com/Victor118/liquidity v1.7.7/go.mod h1:RRGlMTp7z3AKiwbsc9pu4g0hn/UpEyuCrtp3fmzHlGI=
+github.com/Victor118/liquidity v1.8.0 h1:GBWPbZs2019ja2W69ZjO5Hiy1zsG8kAYn0Dbr+qLA1k=
+github.com/Victor118/liquidity v1.8.0/go.mod h1:RRGlMTp7z3AKiwbsc9pu4g0hn/UpEyuCrtp3fmzHlGI=
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/adlio/schema v1.3.6 h1:k1/zc2jNfeiZBA5aFTRy37jlBIuCkXCm0XmvpzCKI9I=

--- a/go.sum
+++ b/go.sum
@@ -243,8 +243,8 @@ github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
-github.com/Victor118/liquidity v1.8.1 h1:Sbv7yR+F1rSFPtxlGKazCio/bsAL11044qic/aYHUDQ=
-github.com/Victor118/liquidity v1.8.1/go.mod h1:RRGlMTp7z3AKiwbsc9pu4g0hn/UpEyuCrtp3fmzHlGI=
+github.com/Victor118/liquidity v1.8.2 h1:xgMvdVzqNQgJ4Mgv/Uy5gzudS7LTXqh8c3hOfHs1gyI=
+github.com/Victor118/liquidity v1.8.2/go.mod h1:RRGlMTp7z3AKiwbsc9pu4g0hn/UpEyuCrtp3fmzHlGI=
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/adlio/schema v1.3.6 h1:k1/zc2jNfeiZBA5aFTRy37jlBIuCkXCm0XmvpzCKI9I=

--- a/scripts/test_node.sh
+++ b/scripts/test_node.sh
@@ -58,7 +58,10 @@ from_scratch () {
   update_test_genesis '.consensus_params["block"]["max_gas"]="100000000"'
   # Gov
   update_test_genesis '.app_state["gov"]["params"]["min_deposit"]=[{"denom": "uhuahua","amount": "1000000"}]'
-  update_test_genesis '.app_state["gov"]["voting_params"]["voting_period"]="15s"'
+  update_test_genesis '.app_state["gov"]["params"]["max_deposit_period"]="5s"'
+  update_test_genesis '.app_state["gov"]["params"]["voting_period"]="20s"'
+  update_test_genesis '.app_state["gov"]["params"]["expedited_voting_period"]="15s"'
+  update_test_genesis '.app_state["gov"]["voting_params"]["voting_period"]="20s"'
   # staking
   update_test_genesis '.app_state["staking"]["params"]["bond_denom"]="uhuahua"'
   update_test_genesis '.app_state["staking"]["params"]["min_commission_rate"]="0.050000000000000000"'

--- a/scripts/test_node.sh
+++ b/scripts/test_node.sh
@@ -32,8 +32,8 @@ alias BINARY="$BINARY --home=$HOME_DIR"
 command -v $BINARY > /dev/null 2>&1 || { echo >&2 "$BINARY command not found. Ensure this is setup / properly installed in your GOPATH (make install)."; exit 1; }
 command -v jq > /dev/null 2>&1 || { echo >&2 "jq not installed. More info: https://stedolan.github.io/jq/download/"; exit 1; }
 
-$BINARY config keyring-backend $KEYRING
-$BINARY config chain-id $CHAIN_ID
+$BINARY config set client keyring-backend $KEYRING
+$BINARY config set client chain-id $CHAIN_ID
 
 from_scratch () {
   # Fresh install on current branch
@@ -55,7 +55,7 @@ from_scratch () {
   }
 
   # Block
-  update_test_genesis '.consensus_params["block"]["max_gas"]="100000000"'
+  update_test_genesis '.consensus["params"]["block"]["max_gas"]="100000000"'
   # Gov
   update_test_genesis '.app_state["gov"]["params"]["min_deposit"]=[{"denom": "uhuahua","amount": "1000000"}]'
   update_test_genesis '.app_state["gov"]["params"]["max_deposit_period"]="5s"'

--- a/x/tokenfactory/abci.go
+++ b/x/tokenfactory/abci.go
@@ -58,10 +58,6 @@ func BeginBlocker(ctx sdk.Context, k keeper.Keeper, bankKeeper types.BankKeeper)
 		}
 	}
 	if !coinsToSend.Empty() {
-		err = bankKeeper.MintCoins(ctx, types.ModuleName, coinsToSend)
-		if err != nil {
-			return err
-		}
 		err = bankKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleName, k.FeeCollectorName, sdk.NewCoins(coinsToSend...))
 		if err != nil {
 			return err

--- a/x/tokenfactory/keeper/createstakedrop.go
+++ b/x/tokenfactory/keeper/createstakedrop.go
@@ -29,14 +29,13 @@ func (k Keeper) createStakedropAfterValidation(ctx sdk.Context, amount sdk.Coin,
 	if err != nil {
 		return err
 	}
-	if amount.Denom == params.BondDenom {
-		//native token, we can mint it so sender need to send it to module account
-		sender := sdk.MustAccAddressFromBech32(creatorAddr)
-		err = k.bankKeeper.SendCoinsFromAccountToModule(ctx, sender, types.ModuleName, sdk.NewCoins(amount))
-		if err != nil {
-			return err
-		}
+
+	sender := sdk.MustAccAddressFromBech32(creatorAddr)
+	err = k.bankKeeper.SendCoinsFromAccountToModule(ctx, sender, types.ModuleName, sdk.NewCoins(amount))
+	if err != nil {
+		return err
 	}
+
 	amountPerBlock := amount.Amount.Quo(math.NewInt(int64(endBlock - startBlock)))
 	newStakedrop := types.Stakedrop{
 		Amount:         amount,


### PR DESCRIPTION
## Changes
- Fixed script issues related to running the local node
- Disabled meme mining for stakedrop on-chain
- Integrated the latest liquidity module supporting permissioned pool creation and updating pool creators via gov proposals
- Set the authority address for liquidity keeper to enable governance-based updates to liquidity params
- Added upgrade handler for v9.0.3